### PR TITLE
feat: usualusdc piils

### DIFF
--- a/src/protocols/protocolList.json
+++ b/src/protocols/protocolList.json
@@ -236,5 +236,29 @@
                 "name": "Resolv points"
             }
         ]
+    },
+    {
+        "ptAddress": "0x4ee81b93cf490f7157144c82ff07557cffd2b86b",
+        "chainId": 1,
+        "protocolName": "Morpho (Usual Boosted USDC)",
+        "token": {
+            "symbol": "USUALUSDC+",
+            "logoURI": "/images/tokens/USUALUSDC.svg",
+            "underlying": "USDC"
+        },
+        "multipliers": {
+            "lp": [
+                {
+                    "amount": 1,
+                    "name": "Pill/day per $1 of USUALUSDC"
+                }
+            ],
+            "yt": [
+                {
+                    "amount": 1,
+                    "name": "Pill/day"
+                }
+            ]
+        }
     }
 ]

--- a/src/schema/protocolList.schema.json
+++ b/src/schema/protocolList.schema.json
@@ -1,4 +1,27 @@
 {
+    "$defs": {
+        "multiplierArray": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "amount",
+                    "name"
+                ],
+                "properties": {
+                    "amount": {
+                        "type": "number",
+                        "minimum": 1,
+                        "maximum": 1000
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    },
     "type": "array",
     "uniqueItems": true,
     "items": {
@@ -46,25 +69,23 @@
                 }
             },
             "multipliers": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                        "amount",
-                        "name"
-                    ],
-                    "properties": {
-                        "amount": {
-                            "type": "number",
-                            "minimum": 1,
-                            "maximum": 1000
-                        },
-                        "name": {
-                            "type": "string"
+                "anyOf": [
+                    {
+                        "$ref": "multiplierArray"
+                    },
+                    {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "lp": {
+                                "$ref": "multiplierArray"
+                            },
+                            "yt": {
+                                "$ref": "multiplierArray"
+                            }
                         }
                     }
-                }
+                ]
             }
         }
     }


### PR DESCRIPTION
See https://github.com/perspectivefi/spectra-app/pull/1982
This PR adds USUALUSDC pills for YT and LP separately, hence the slight modification of the schema too:
mutlipliers is now either an array of Multiplier, or an object with `{ yt?: Multiplier[], lp?: Multiplier[] }`