### PR TITLE
Add WSEI reward aprEndpoint to Takara wrappers on Sei

### DIFF
--- a/src/wrappers/1329/0x4580221962a8d0f92c18f320ea512f70933f7d19/index.json
+++ b/src/wrappers/1329/0x4580221962a8d0f92c18f320ea512f70933f7d19/index.json
@@ -7,6 +7,7 @@
     "logoURI": "/images/tokens/1329/0xa82a40324dbf7b57e87bd07c9e1d722e9754be9b.svg",
     "extensions": {
         "protocol": "Takara",
+        "aprEndpoint": "https://app.spectra.finance/api/ibt-apr/sei/0x4580221962A8D0F92c18F320eA512f70933f7D19",
         "vault": {
             "chainId": 1329,
             "address": "0xA82a40324DBf7B57E87bD07C9e1D722E9754be9B",

--- a/src/wrappers/1329/0x79ffb1caa21ba491200a68498117a639e3e8df80/index.json
+++ b/src/wrappers/1329/0x79ffb1caa21ba491200a68498117a639e3e8df80/index.json
@@ -7,6 +7,7 @@
     "logoURI": "/images/tokens/1329/0xd1e6a6f58a29f64ab2365947acb53efeb6cc05e0.png",
     "extensions": {
         "protocol": "Takara",
+        "aprEndpoint": "https://app.spectra.finance/api/ibt-apr/sei/0x79Ffb1cAa21Ba491200A68498117a639E3E8df80",
         "vault": {
             "chainId": 1329,
             "address": "0xd1E6a6F58A29F64ab2365947ACb53EfEB6Cc05e0",


### PR DESCRIPTION
## What

Adds `extensions.aprEndpoint` to the two Spectra ERC-4626 Takara wrappers on Sei (chainId 1329):

| Wrapper | Address | aprEndpoint |
|---|---|---|
| `sw-tUSDT0` | `0x4580…7D19` | `…/api/ibt-apr/sei/0x4580…7D19` |
| `sw-tnUSDC` | `0x79Ff…df80` | `…/api/ibt-apr/sei/0x79Ff…df80` |

## Why

Takara streams **WSEI** supply-side incentives to each lending market; our wrappers hold the tToken and earn those emissions (redistributed to holders via Merkl). The new `/ibt-apr/sei/<wrapper>` route on `api.spectra.finance` computes the annualized WSEI reward APR for each market. Wiring `aprEndpoint` here lets the backend (`getAppData → getAPREndpoints → getIBTRewardsAPR`) surface it under `ibt.apr.details.rewards`.

Live values from the new route (matching the Takara UI's total APR): `sw-tnUSDC` ≈ 5.77%, `sw-tUSDT0` ≈ 2.0%.

## Notes

- These addresses are reused on other chains (999/HyperEVM, 43114, 1) via deterministic deploys — **only the 1329/Sei entries** are touched here, and the URL carries the `sei` slug so the route resolves to the correct market.
- `aprEndpoint` is an existing, schema-valid extension field (already used by Avalanche wrappers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
