### PR TITLE
Change Firelight points multiplier from 2x to 1x

### DIFF
--- a/src/protocols/protocolList.json
+++ b/src/protocols/protocolList.json
@@ -1145,7 +1145,7 @@
         "chainId": 14,
         "multipliers": [
             {
-                "amount": 2,
+                "amount": 1,
                 "name": "Firelight points"
             }
         ]
@@ -1155,7 +1155,7 @@
         "chainId": 14,
         "multipliers": [
             {
-                "amount": 2,
+                "amount": 1,
                 "name": "Firelight points"
             }
         ]
@@ -1229,7 +1229,7 @@
         "chainId": 14,
         "multipliers": [
             {
-                "amount": 2,
+                "amount": 1,
                 "name": "Firelight points"
             }
         ]
@@ -1239,7 +1239,7 @@
         "chainId": 14,
         "multipliers": [
             {
-                "amount": 2,
+                "amount": 1,
                 "name": "Firelight points"
             }
         ]


### PR DESCRIPTION
Updates all four Firelight points entries in `protocolList.json` (chain 14) from a 2x to a 1x multiplier:

- `0x097dd93bf92bf9018ff194195ddfcfb2c359335e`
- `0x04304b039ae6c02acd9830e1bb0e8f529cb9a2a6`
- `0x91bada8de2119aaab49bf1d5e3daafd707b088a6`
- `0xa7cb1fa9aab0157f0380b29e48dfe2b305171181`

🤖 Generated with [Claude Code](https://claude.com/claude-code)