### PR TITLE
Fix CI: Node 22 for npm 12, revive token validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: "20"
+                  node-version: "22"
                   registry-url: "https://registry.npmjs.org"
 
             # Ensure npm 11.5.1 or later is installed

--- a/.github/workflows/token-validation.yml
+++ b/.github/workflows/token-validation.yml
@@ -6,24 +6,24 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   ref: ${{ github.head_ref }}
 
             - name: Validate Tokens
               uses: nhalstead/validate-json-action@0.1.3
-              env:
-                  INPUT_SCHEMA: src/schema/token.schema.json
-                  INPUT_JSONS: src/tokens/*.json
+              with:
+                  schema: src/schema/token.schema.json
+                  jsons: src/tokens/**/*.json
 
             - name: Validate Wrappers
               uses: nhalstead/validate-json-action@0.1.3
-              env:
-                  INPUT_SCHEMA: src/schema/token.schema.json
-                  INPUT_JSONS: src/wrappers/*.json
+              with:
+                  schema: src/schema/token.schema.json
+                  jsons: src/wrappers/**/*.json
 
             - name: Validate Protocol List
               uses: nhalstead/validate-json-action@0.1.3
-              env:
-                  INPUT_SCHEMA: src/schema/protocolList.schema.json
-                  INPUT_JSONS: src/protocols/protocolList.json
+              with:
+                  schema: src/schema/protocolList.schema.json
+                  jsons: src/protocols/protocolList.json

--- a/src/schema/protocolList.schema.json
+++ b/src/schema/protocolList.schema.json
@@ -6,7 +6,6 @@
                 "type": "object",
                 "additionalProperties": false,
                 "required": [
-                    "amount",
                     "name"
                 ],
                 "properties": {
@@ -45,17 +44,17 @@
             "multipliers": {
                 "anyOf": [
                     {
-                        "$ref": "multiplierArray"
+                        "$ref": "#/$defs/multiplierArray"
                     },
                     {
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
                             "lp": {
-                                "$ref": "multiplierArray"
+                                "$ref": "#/$defs/multiplierArray"
                             },
                             "yt": {
-                                "$ref": "multiplierArray"
+                                "$ref": "#/$defs/multiplierArray"
                             }
                         }
                     }

--- a/src/schema/token.schema.json
+++ b/src/schema/token.schema.json
@@ -6,8 +6,7 @@
         "address",
         "name",
         "symbol",
-        "decimals",
-        "logoURI"
+        "decimals"
     ],
     "properties": {
         "chainId": {
@@ -26,7 +25,7 @@
         "decimals": {
             "type": "integer",
             "minimum": 1,
-            "maximum": 18
+            "maximum": 255
         },
         "logoURI": {
             "type": "string"
@@ -87,6 +86,9 @@
                         },
                         "unwrap": {
                             "type": "boolean"
+                        },
+                        "wrap": {
+                            "type": "boolean"
                         }
                     }
                 },
@@ -114,12 +116,18 @@
                         "decimals": {
                             "type": "integer",
                             "minimum": 1,
-                            "maximum": 18
+                            "maximum": 255
                         },
                         "logoURI": {
                             "type": "string"
+                        },
+                        "extensions": {
+                            "type": "object"
                         }
                     }
+                },
+                "displayMode": {
+                    "type": "string"
                 }
             }
         }

--- a/src/tokens/1/0xf244324fbb57f09f0606ff088bc894b051d632eb/index.json
+++ b/src/tokens/1/0xf244324fbb57f09f0606ff088bc894b051d632eb/index.json
@@ -6,7 +6,6 @@
   "decimals": 18,
   "logoURI": "/images/tokens/1/0xf244324fbb57f09f0606ff088bc894b051d632eb.svg",
   "extensions": {
-    "underlying": "",
     "protocol": "Yearn (Level)"
   }
 }

--- a/src/wrappers/1329/0xb9003d5bed06afd570139d21c64817298dd47ec1/index.json
+++ b/src/wrappers/1329/0xb9003d5bed06afd570139d21c64817298dd47ec1/index.json
@@ -8,7 +8,7 @@
     "extensions": {
         "underlying": "0xE30feDd158A2e3b13e9badaeABaFc5516e95e8C7",
         "protocol": "Splashing",
-        "exeternalLink": "https://www.splashing.xyz",
+        "externalLink": "https://www.splashing.xyz",
         "vault": {
             "chainId": 1329,
             "address": "0xC257361320F4514D91c05F461006CE6a0300E2d2",


### PR DESCRIPTION
## Why

Two CI problems, both surfaced by [run 29001197573](https://github.com/perspectivefi/token-list/actions/runs/29001197573):

**1. `Package update` (deploy) fails on `Update npm`.** npm published v12, which requires Node ≥ 22.22.2, so `npm install -g npm@latest` on the pinned Node 20 dies with `EBADENGINE`. Fixed by bumping `setup-node` to Node 22 (Node 20 is EOL since April 2026 anyway).

**2. `Token validation` has been red on every PR — and was vacuous even before that.**
- Inputs were passed via `env: INPUT_*`, which the runner no longer forwards into the action's Docker container → `🚨 Missing JSONS input` on every run.
- Even historically, the globs (`src/tokens/*.json`) matched **zero** files, since tokens live at `src/tokens/<chainId>/<address>/index.json` — so validation never actually checked anything.
- `protocolList.schema.json` used `"$ref": "multiplierArray"`, which ajv can't resolve — that step would have crashed even with working inputs.

## What

**Workflows**
- `deploy.yml`: `node-version: 20 → 22`
- `token-validation.yml`: pass inputs via `with:`, use `**/*.json` globs, bump `checkout` v2 → v4

**Schemas** — synced with data already shipped in production:
- `decimals` max 18 → 255 (the list has live 20- and 24-decimals tokens)
- allow `extensions.displayMode`, `ibtRoutes.wrap`, `vault.extensions`
- `logoURI` and multiplier `amount` are now optional (published entries omit them — e.g. name-only points multipliers)
- fix `$ref`s to JSON pointers (`#/$defs/multiplierArray`)

**Data bugs** the dead validation never caught:
- `exeternalLink` → `externalLink` typo on sw-spSEI (Sei) — the link was silently ignored
- removed empty `"underlying": ""` on s/lvlUSD

## Verification

Ran all 452 files (350 tokens, 101 wrappers, protocolList) through ajv@6 — the exact validator the action pins — with the new globs and schemas: **0 failures**. The Token validation check on this PR now exercises the real files for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)