### PR TITLE
Pin npm to 11.x, drop head_ref checkout in validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,11 @@ jobs:
                   node-version: "22"
                   registry-url: "https://registry.npmjs.org"
 
-            # Ensure npm 11.5.1 or later is installed
+            # npm >= 11.5.1 is required for trusted publishing.
+            # Pinned to 11.x: npm 12 rejects the -iwr flag used by
+            # gh-action-bump-version (phips28/gh-action-bump-version#index.js).
             - name: Update npm
-              run: npm install -g npm@latest
+              run: npm install -g npm@11
             - run: npm ci
 
             - name: Automated Version Bump

--- a/.github/workflows/token-validation.yml
+++ b/.github/workflows/token-validation.yml
@@ -7,8 +7,6 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-              with:
-                  ref: ${{ github.head_ref }}
 
             - name: Validate Tokens
               uses: nhalstead/validate-json-action@0.1.3


### PR DESCRIPTION
Follow-up to #394 — the Node 22 bump got `Update npm` and `npm ci` green, but the deploy now fails one step later ([run 29018585990](https://github.com/perspectivefi/token-list/actions/runs/29018585990)):

**`Automated Version Bump` breaks on npm 12.** `phips28/gh-action-bump-version@master` runs `npm config set fund false -ws=false -iwr`, and npm 12 removed single-hyphen long flags → `-iwr is not a valid single-hyphen cli flag`. Broken upstream ([index.js:202](https://github.com/phips28/gh-action-bump-version/blob/master/index.js#L202), untouched since March). Fix: pin `npm install -g npm@11` — the same npm major as the last green deploy (July 3), still ≥ 11.5.1 for trusted publishing.

**Also:** the Token validation check on #394 "failed" only because it ran after the merge auto-deleted the branch — `checkout` with `ref: ${{ github.head_ref }}` had nothing to fetch. Dropped the override so checkout uses the default PR merge commit, which survives branch deletion and works for fork PRs. This PR's own check should finally show validation running end-to-end.

Merging this triggers the deploy on main, which will version-bump and publish the Firelight multiplier change that's been stuck since this morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)